### PR TITLE
Support variant/individual identifies, V4 format changes

### DIFF
--- a/examples/igdread.py
+++ b/examples/igdread.py
@@ -1,0 +1,24 @@
+import pyigd
+import sys
+
+if len(sys.argv) < 2:
+    print("Pass in IGD filename")
+    exit(1)
+
+with pyigd.IGDFile(sys.argv[1]) as igd_file:
+    print(f"Version: {igd_file.version}")
+    print(f"Ploidy: {igd_file.ploidy}")
+    print(f"Variants: {igd_file.num_variants}")
+    print(f"Individuals: {igd_file.num_individuals}")
+    print(f"Source: {igd_file.source}")
+    print(f"Description: {igd_file.description}")
+    for variant_index in range(igd_file.num_variants):
+        # Approach 1: Get the samples as a list
+        print(f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}")
+        position, is_missing, sample_list = igd_file.get_samples(variant_index)
+        print( (position, is_missing, len(sample_list))  )
+
+        # Approach 2: Get the samples as a BitVector object
+        # See https://engineering.purdue.edu/kak/dist/BitVector-3.5.0.html
+        position, is_missing, bitvect = igd_file.get_samples_bv(variant_index)
+        print( (position, is_missing, bitvect.count_bits())  )

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -26,13 +26,22 @@ def _write_u64(file_obj, value):
 def _write_u32(file_obj, value):
     file_obj.write(struct.pack("I", value))
 
+def _write_str(ver3, file_obj, string):
+    if ver3:
+        _write_u64(file_obj, len(string))
+    else:
+        _write_u32(file_obj, len(string))
+    file_obj.write(string.encode("utf-8"))
+
 class IGDTestFile(tempfile.TemporaryDirectory):
     FILENAME = "test.igd"
 
-    def __init__(self, header, variants=[]):
+    def __init__(self, header, variants=[], indiv_ids=[], ver3=False):
         super().__init__()
         self.header = header
         self.variants = variants
+        self.ver3 = ver3
+        self.indiv_ids = indiv_ids
 
     def __enter__(self, *args):
         tmpdir = super().__enter__(*args)
@@ -43,14 +52,12 @@ class IGDTestFile(tempfile.TemporaryDirectory):
             f.write(self.header)
 
             # Write the two strings immediately following header (required)
-            _write_u64(f, len(TEST_SOURCE))
-            f.write(TEST_SOURCE.encode("utf-8"))
-            _write_u64(f, len(TEST_DESCRIPTION))
-            f.write(TEST_DESCRIPTION.encode("utf-8"))
+            _write_str(self.ver3, f, TEST_SOURCE)
+            _write_str(self.ver3, f, TEST_DESCRIPTION)
 
             # Write the genotype data first.
             file_positions = []
-            for _, _, sample_list in self.variants:
+            for _, _, sample_list, _ in self.variants:
                 file_positions.append(f.tell())
                 _write_u32(f, len(sample_list))
                 for sample_idx in sample_list:
@@ -58,7 +65,7 @@ class IGDTestFile(tempfile.TemporaryDirectory):
 
             # Then write the index.
             fp_idx = f.tell()
-            for (position, is_missing, _), fp in zip(self.variants, file_positions):
+            for (position, is_missing, _, _), fp in zip(self.variants, file_positions):
                 flags = BpPosFlags.SPARSE.value
                 if is_missing:
                     flags |= BpPosFlags.IS_MISSING.value
@@ -66,10 +73,34 @@ class IGDTestFile(tempfile.TemporaryDirectory):
                 _write_u64(f, encoded_pos)
                 _write_u64(f, fp)
 
+            # If provided write the individual ids
+            if self.indiv_ids:
+                fp_indivs = f.tell()
+                _write_u64(f, len(self.indiv_ids))
+                for ident in self.indiv_ids:
+                    _write_str(self.ver3, f, ident)
+            else:
+                fp_indivs = 0
+
+            # If provided write the variant ids
+            var_ids = [ident for _,_,_,ident in self.variants if ident is not None]
+            if var_ids:
+                fp_varids = f.tell()
+                _write_u64(f, len(var_ids))
+                for ident in var_ids:
+                    _write_str(self.ver3, f, ident)
+            else:
+                fp_varids = 0
+
+            fp_vars = 0
+
             # Gross. If this wasn't test code I wouldn't do this...
-            # We're just updating one field of the header to set the location of the index.
+            # We're just updating the last few fields of the header to set the file locations.
             f.seek(0 + (6*8))
             _write_u64(f, fp_idx)
+            _write_u64(f, fp_vars)
+            _write_u64(f, fp_indivs)
+            _write_u64(f, fp_varids)
             f.flush()
 
         return tmpdir
@@ -96,7 +127,7 @@ class BasicTests(unittest.TestCase):
             random.shuffle(result)
             return sorted(result[:count])
 
-        variants = list(sorted([(random.randint(0, 100_000), False, rand_samples())
+        variants = list(sorted([(random.randint(0, 100_000), False, rand_samples(), None)
                                 for i in range(V)], key=lambda v: v[0]))
 
         with IGDTestFile(make_header(individuals=I, variants=V), variants) as tmpdir:
@@ -110,7 +141,73 @@ class BasicTests(unittest.TestCase):
 
             for i in range(V):
                 pos, m, samples = igd_file.get_samples(i)
-                orig_pos, orig_m, orig_samples = variants[i]
+                orig_pos, orig_m, orig_samples, _ = variants[i]
                 self.assertEqual(pos, orig_pos)
                 self.assertEqual(m, orig_m)
                 self.assertEqual(samples, orig_samples)
+
+            self.assertEqual(len(igd_file.get_individual_ids()), 0)
+
+    def test_good_indiv_ids(self):
+        I = 10
+        with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I)))) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            igd_file = IGDFile(filename)
+            self.assertEqual(igd_file.num_individuals, I)
+            self.assertEqual(igd_file.get_individual_ids(), list(map(str, range(I))))
+
+    def test_bad_indiv_ids(self):
+        I = 10
+        with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I+1)))) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            igd_file = IGDFile(filename)
+            with self.assertRaises(AssertionError):
+                igd_file.get_individual_ids()
+
+    def test_bad_var_ids(self):
+        V = 25
+        variants = [(i,False,[],(None if i > 5 else str(i))) for i in range(V)]
+        with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            igd_file = IGDFile(filename)
+            with self.assertRaises(AssertionError):
+                igd_file.get_variant_ids()
+
+    def test_good_var_ids(self):
+        V = 21
+        variants = [(i,False,[],str(i)) for i in range(V)]
+        with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            igd_file = IGDFile(filename)
+            self.assertEqual(igd_file.get_variant_ids(),
+                             [v[3] for v in variants])
+
+
+class CompatTests(unittest.TestCase):
+    def test_bad_header_ver(self):
+        with IGDTestFile(make_header(version=1)) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            with self.assertRaises(AssertionError):
+                _ = IGDFile(filename)
+
+    def test_bad_header_magic(self):
+        with IGDTestFile(make_header(magic=0xbaadf00d)) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            with self.assertRaises(AssertionError):
+                _ = IGDFile(filename)
+
+    def test_v3_compatible(self):
+        I = 10
+        V = 50
+        with IGDTestFile(make_header(version=3, individuals=I, variants=V), ver3=True) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            igd_file = IGDFile(filename)
+
+            self.assertEqual(igd_file.description, TEST_DESCRIPTION)
+            self.assertEqual(igd_file.source, TEST_SOURCE)
+            self.assertEqual(igd_file.num_individuals, I)
+            self.assertEqual(igd_file.num_variants, V)
+            self.assertEqual(igd_file.ploidy, 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Backwards compatible with IGD format V3 still.
* V4 reduces some string sizes
* Support reading the (optional) tables for variant and individual identifiers
* Add a bunch of unit tests