### PR TITLE
Add IGDWriter, IGDFile->IGDReader, and add IGDTransformer

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest BitVector
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -23,34 +23,13 @@ pip install --force-reinstall dist/*.whl
 
 ## Usage
 
-The `pyigd.IGDFile` class is a context manager, so it is recommended that you use it via the `with` statement. Below is an example script that loads an IGD file, prints out some meta-data, and then iterates the genotype data for all variants.
-
+The `pyigd.IGDReader` class reads IGD data from a buffer. See [the example script](https://github.com/aprilweilab/pyigd/blob/main/examples/igdread.py) that loads an IGD file, prints out some meta-data, and then iterates the genotype data for all variants. Generally the usage pattern is:
 ```
-import pyigd
-import sys
-
-if len(sys.argv) < 2:
-    print("Pass in IGD filename")
-    exit(1)
-
-with pyigd.IGDFile(sys.argv[1]) as igd_file:
-    print(f"Version: {igd_file.version}")
-    print(f"Ploidy: {igd_file.ploidy}")
-    print(f"Variants: {igd_file.num_variants}")
-    print(f"Individuals: {igd_file.num_individuals}")
-    print(f"Source: {igd_file.source}")
-    print(f"Description: {igd_file.description}")
-    for variant_index in range(igd_file.num_variants):
-        # Approach 1: Get the samples as a list
-        print(f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}")
-        position, is_missing, sample_list = igd_file.get_samples(variant_index)
-        print( (position, is_missing, len(sample_list))  )
-
-        # Approach 2: Get the samples as a BitVector object
-        # See https://engineering.purdue.edu/kak/dist/BitVector-3.5.0.html
-        position, is_missing, bitvect = igd_file.get_samples_bv(variant_index)
-        print( (position, is_missing, bitvect.count_bits())  )
+with open(filename, "rb") as f:
+  igd_reader = pyigd.IGDReader(f)
 ```
+
+There is also the `pyigd.IGDWriter` class to construct IGD files. Related is `pyigd.IGDTransformer`, which is a way to create a copy of an IGD while modifying its contents. See the IGDTransformer [sample list example](https://github.com/aprilweilab/pyigd/blob/main/examples/xform.py) and [bitvector example](https://github.com/aprilweilab/pyigd/blob/main/examples/xform_bv.py).
 
 IGD can be highly performant for a few reasons:
 1. It stores sparse data sparsely. Low-frequency variants are stored as sample lists. Medium/high frequency variants are stored as bit vectors.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,28 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'pyigd'
+copyright = '2024, Drew DeHaas'
+author = 'Drew DeHaas'
+release = '0.2'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc"]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,74 @@
+.. pyigd documentation master file, created by
+   sphinx-quickstart on Wed Aug 21 14:20:22 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+pyigd Documentation
+===================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+pyigd is a Python library for reading and writing Indexable Genotype Data
+(IGD) files. `IGD is a binary format <https://github.com/aprilweilab/picovcf/blob/main/IGD.FORMAT.md>`_ that is very simple and uses no
+compression, but tends to be quite small and fast.
+
+IGDReader example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example of how to read an IGD file. See :py:class:`pyigd.IGDReader` for the relevant API reference.
+
+::
+
+  import pyigd
+  import sys
+
+  if len(sys.argv) < 2:
+      print("Pass in IGD filename")
+      exit(1)
+
+  with open(sys.argv[1], "rb") as f:
+      igd_file = pyigd.IGDReader(f)
+      print(f"Version: {igd_file.version}")
+      print(f"Ploidy: {igd_file.ploidy}")
+      print(f"Variants: {igd_file.num_variants}")
+      print(f"Individuals: {igd_file.num_individuals}")
+      print(f"Source: {igd_file.source}")
+      print(f"Description: {igd_file.description}")
+      for variant_index in range(igd_file.num_variants):
+          print(f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}")
+          position, is_missing, sample_list = igd_file.get_samples(variant_index)
+          print( (position, is_missing, len(sample_list))  )
+
+IGDWriter example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example of how to write an IGD file. See :py:class:`pyigd.IGDWriter` for the relevant API reference. Some of the methods invoked have a required order, and in general all the variants (sample info) needs to be written immediately after the header. The IGDWriter maintains some state, and for large datasets can use a non-trivial amount of RAM to maintain indexes while writing variant data.
+
+::
+
+  num_individuals = 100
+  with open("output.igd", "wb") as f:
+      w = IGDWriter(f, num_individuals)
+      w.write_header()
+      w.write_variant(100, "A", "G", [1, 22, 99, 101])
+      w.write_variant(101, "A", "C", list(range(200)))
+      w.write_index()
+      w.write_variant_info()
+      w.write_individual_ids([]) # optional
+      w.write_variant_ids([])    # optional
+      # We write the header twice because the IGDWriter is updating fields
+      # on the header as we call the other methods above. For example, it is
+      # counting the number of variants being written and that gets updated
+      # in the header the second time we write it.
+      f.seek(0)
+      w.write_header()
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+pyigd
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   pyigd

--- a/docs/pyigd.rst
+++ b/docs/pyigd.rst
@@ -1,0 +1,10 @@
+pyigd package
+=============
+
+Module contents
+---------------
+
+.. automodule:: pyigd
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/igdread.py
+++ b/examples/igdread.py
@@ -5,7 +5,8 @@ if len(sys.argv) < 2:
     print("Pass in IGD filename")
     exit(1)
 
-with pyigd.IGDFile(sys.argv[1]) as igd_file:
+with open(sys.argv[1], "rb") as f:
+    igd_file = pyigd.IGDReader(f)
     print(f"Version: {igd_file.version}")
     print(f"Ploidy: {igd_file.ploidy}")
     print(f"Variants: {igd_file.num_variants}")

--- a/examples/xform.py
+++ b/examples/xform.py
@@ -1,0 +1,18 @@
+import pyigd
+import sys
+
+if len(sys.argv) < 3:
+    print("Pass in IGD input/output filenames")
+    exit(1)
+
+# Our own IGDTransformer. This just deletes the first sample from every variant, but
+# in general you can change the sample list any way you want. Return None to delete
+# the variant entirely.
+class MyXformer(pyigd.IGDTransformer):
+    def modify_samples(self, position, is_missing, samples):
+        return samples[1:]
+
+with open(sys.argv[1], "rb") as fin, open(sys.argv[2], "wb") as fout:
+    xformer = MyXformer(fin, fout, use_bitvectors=False)
+    xformer.transform()
+print(f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant.")

--- a/examples/xform_bv.py
+++ b/examples/xform_bv.py
@@ -1,0 +1,22 @@
+import pyigd
+import sys
+
+if len(sys.argv) < 3:
+    print("Pass in IGD input/output filenames")
+    exit(1)
+
+# Our own IGDTransformer. This just deletes the first sample from every variant, but
+# in general you can change the sample list any way you want. Return None to delete
+# the variant entirely.
+class MyXformer(pyigd.IGDTransformer):
+    def modify_samples(self, position, is_missing, samples):
+        # BitVector version. The ith element being 1 means the ith sample has the variant.
+        for i in range(len(samples)):
+            if samples[i]:
+                samples[i] = 0
+        return samples
+
+with open(sys.argv[1], "rb") as fin, open(sys.argv[2], "wb") as fout:
+    xformer = MyXformer(fin, fout, use_bitvectors=True)
+    xformer.transform()
+print(f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant.")

--- a/pyigd/__init__.py
+++ b/pyigd/__init__.py
@@ -99,7 +99,7 @@ class IGDReader:
         self._before_first_var = self.file_obj.tell()
         self._all_refs = None
         self._all_alts = None
-    
+
     def _read_allele_info(self):
         self.file_obj.seek(self._fp_vars)
         self._all_refs = []
@@ -325,16 +325,19 @@ class IGDHeader:
 
     def pack(self) -> bytes:
         return struct.pack(IGDConstants.HEADER_FORMAT,
-            self.magic, self.version, self.ploidy, self.sparse_threshold, self.num_variants,
-            self.num_individuals, self.flags, self.fp_index, self.fp_variants,
-            self.fp_individualids, self.fp_variantids, 0, 0, 0, 0, 0, 0)
+                           self.magic, self.version, self.ploidy, self.sparse_threshold,
+                           self.num_variants, self.num_individuals, self.flags, self.fp_index,
+                           self.fp_variants, self.fp_individualids, self.fp_variantids,
+                           0, 0, 0, 0, 0, 0)
 
 
 def _write_u64(file_obj, value):
     file_obj.write(struct.pack("Q", value))
 
+
 def _write_u32(file_obj, value):
     file_obj.write(struct.pack("I", value))
+
 
 def _write_str(file_obj, string):
     _write_u32(file_obj, len(string))
@@ -392,7 +395,7 @@ class IGDWriter:
         self.out.write(self.header.pack())
         _write_str(self.out, self.source)
         _write_str(self.out, self.description)
-    
+
     @staticmethod
     def _make_index_entry(position: int,
                           is_missing: bool,
@@ -454,7 +457,7 @@ class IGDWriter:
                 data[element] = data[element] | (1 << bit)
             self.out.write(struct.pack("B"*num_bytes, *data))
         self.header.num_variants += 1
-    
+
     def write_index(self):
         """
         Write the variant position index. Must be called _after_  all calls to write_variant().
@@ -552,8 +555,8 @@ class IGDTransformer:
                             samples_list.append(s)
                     samples = samples_list
                 self.writer.write_variant(position,
-                                          self.reader.get_ref_allele(i), 
-                                          self.reader.get_alt_allele(i), 
+                                          self.reader.get_ref_allele(i),
+                                          self.reader.get_alt_allele(i),
                                           samples)
         self.writer.write_index()
         self.writer.write_variant_info()

--- a/pyigd/__init__.py
+++ b/pyigd/__init__.py
@@ -1,10 +1,11 @@
 """
 Module for reading and writing Indexable Genotype Data (IGD) files.
 """
-import struct
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
 from enum import Enum
 from typing import BinaryIO, List, Tuple, Union, Optional
-from dataclasses import dataclass
+import struct
 # Optional import. BitVector is only needed when using the APIs that return them.
 try:
     import BitVector  # type: ignore
@@ -306,6 +307,27 @@ class IGDReader:
             for _ in range(count):
                 result.append(_read_string(self._version, self.file_obj))
         return result
+
+
+class IGDFile(IGDReader, AbstractContextManager):
+    """
+    DEPRECATED DO NOT USE. Context object for loading an IGD file. See IGDReader instead.
+
+    :param filename: The filename to open.
+    """
+    def __init__(self, filename: str):
+        file_obj = open(filename, "rb")
+        super().__init__(file_obj)
+
+    def __del__(self):
+        if self.file_obj is not None:
+            self.file_obj.close()
+        self.file_obj = None
+
+    def __exit__(self, *args):
+        if self.file_obj is not None:
+            self.file_obj.close()
+        self.file_obj = None
 
 
 # Internal class for managing the fixed-sized header of an IGD file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "pyigd"
-version = "0.1"
+version = "0.2"
 authors = [
   { name="Drew DeHaas" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 PACKAGE_NAME = "pyigd"
-VERSION = "0.1"
+VERSION = "0.2"
 
 setup(name=PACKAGE_NAME,
       packages=find_packages(),

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,4 +1,5 @@
 from pyigd import IGDReader, IGDConstants, BpPosFlags
+from pyigd import IGDFile # TODO: remove
 import unittest
 import struct
 import tempfile
@@ -116,6 +117,17 @@ class ReaderTests(unittest.TestCase):
                 self.assertEqual(igd_file.num_individuals, 0)
                 self.assertEqual(igd_file.num_variants, 0)
                 self.assertEqual(igd_file.ploidy, 2)
+
+    def test_good_header_no_data_old_style(self):
+        with IGDTestFile(make_header()) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            with IGDFile(filename) as igd_file:
+                self.assertEqual(igd_file.description, TEST_DESCRIPTION)
+                self.assertEqual(igd_file.source, TEST_SOURCE)
+                self.assertEqual(igd_file.num_individuals, 0)
+                self.assertEqual(igd_file.num_variants, 0)
+                self.assertEqual(igd_file.ploidy, 2)
+
 
     def test_good_header_some_data(self):
         I = 10

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,4 +1,4 @@
-from pyigd import IGDFile, BpPosFlags
+from pyigd import IGDReader, IGDConstants, BpPosFlags
 import unittest
 import struct
 import tempfile
@@ -8,15 +8,15 @@ import random
 TEST_SOURCE = "SOURCE"
 TEST_DESCRIPTION = "DESCRIPTION"
 
-def make_header(magic=IGDFile.HEADER_MAGIC,
-                version=IGDFile.SUPPORTED_FILE_VERSION,
+def make_header(magic=IGDConstants.HEADER_MAGIC,
+                version=IGDConstants.SUPPORTED_FILE_VERSION,
                 ploidy=2,
                 variants=0,
                 individuals=0,
                 fp_idx=0,
                 fp_vars=0,
                 fp_indv=0):
-    return struct.pack(IGDFile.HEADER_FORMAT,
+    return struct.pack(IGDConstants.HEADER_FORMAT,
         magic, version, ploidy, 0, variants, individuals, 0, fp_idx, fp_vars, fp_indv,
         0, 0, 0, 0, 0, 0, 0)
 
@@ -105,16 +105,17 @@ class IGDTestFile(tempfile.TemporaryDirectory):
 
         return tmpdir
 
-class BasicTests(unittest.TestCase):
+class ReaderTests(unittest.TestCase):
     def test_good_header_no_data(self):
         with IGDTestFile(make_header()) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            self.assertEqual(igd_file.description, TEST_DESCRIPTION)
-            self.assertEqual(igd_file.source, TEST_SOURCE)
-            self.assertEqual(igd_file.num_individuals, 0)
-            self.assertEqual(igd_file.num_variants, 0)
-            self.assertEqual(igd_file.ploidy, 2)
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                self.assertEqual(igd_file.description, TEST_DESCRIPTION)
+                self.assertEqual(igd_file.source, TEST_SOURCE)
+                self.assertEqual(igd_file.num_individuals, 0)
+                self.assertEqual(igd_file.num_variants, 0)
+                self.assertEqual(igd_file.ploidy, 2)
 
     def test_good_header_some_data(self):
         I = 10
@@ -132,82 +133,90 @@ class BasicTests(unittest.TestCase):
 
         with IGDTestFile(make_header(individuals=I, variants=V), variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            self.assertEqual(igd_file.description, TEST_DESCRIPTION)
-            self.assertEqual(igd_file.source, TEST_SOURCE)
-            self.assertEqual(igd_file.num_individuals, I)
-            self.assertEqual(igd_file.num_variants, V)
-            self.assertEqual(igd_file.ploidy, 2)
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                self.assertEqual(igd_file.description, TEST_DESCRIPTION)
+                self.assertEqual(igd_file.source, TEST_SOURCE)
+                self.assertEqual(igd_file.num_individuals, I)
+                self.assertEqual(igd_file.num_variants, V)
+                self.assertEqual(igd_file.ploidy, 2)
 
-            for i in range(V):
-                pos, m, samples = igd_file.get_samples(i)
-                orig_pos, orig_m, orig_samples, _ = variants[i]
-                self.assertEqual(pos, orig_pos)
-                self.assertEqual(m, orig_m)
-                self.assertEqual(samples, orig_samples)
+                for i in range(V):
+                    pos, m, samples = igd_file.get_samples(i)
+                    orig_pos, orig_m, orig_samples, _ = variants[i]
+                    self.assertEqual(pos, orig_pos)
+                    self.assertEqual(m, orig_m)
+                    self.assertEqual(samples, orig_samples)
 
-            self.assertEqual(len(igd_file.get_individual_ids()), 0)
+                self.assertEqual(len(igd_file.get_individual_ids()), 0)
 
     def test_good_indiv_ids(self):
         I = 10
         with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I)))) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            self.assertEqual(igd_file.num_individuals, I)
-            self.assertEqual(igd_file.get_individual_ids(), list(map(str, range(I))))
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                self.assertEqual(igd_file.num_individuals, I)
+                self.assertEqual(igd_file.get_individual_ids(), list(map(str, range(I))))
 
     def test_bad_indiv_ids(self):
         I = 10
         with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I+1)))) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            with self.assertRaises(AssertionError):
-                igd_file.get_individual_ids()
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                with self.assertRaises(AssertionError):
+                    igd_file.get_individual_ids()
 
     def test_bad_var_ids(self):
         V = 25
         variants = [(i,False,[],(None if i > 5 else str(i))) for i in range(V)]
         with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            with self.assertRaises(AssertionError):
-                igd_file.get_variant_ids()
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                with self.assertRaises(AssertionError):
+                    igd_file.get_variant_ids()
 
     def test_good_var_ids(self):
         V = 21
         variants = [(i,False,[],str(i)) for i in range(V)]
         with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
-            self.assertEqual(igd_file.get_variant_ids(),
-                             [v[3] for v in variants])
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+                self.assertEqual(igd_file.get_variant_ids(),
+                                [v[3] for v in variants])
 
 
 class CompatTests(unittest.TestCase):
     def test_bad_header_ver(self):
         with IGDTestFile(make_header(version=1)) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            with self.assertRaises(AssertionError):
-                _ = IGDFile(filename)
+            with open(filename, "rb") as f:
+                with self.assertRaises(AssertionError):
+                    _ = IGDReader(f)
 
     def test_bad_header_magic(self):
         with IGDTestFile(make_header(magic=0xbaadf00d)) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            with self.assertRaises(AssertionError):
-                _ = IGDFile(filename)
+            with open(filename, "rb") as f:
+                with self.assertRaises(AssertionError):
+                    _ = IGDReader(f)
 
     def test_v3_compatible(self):
         I = 10
         V = 50
         with IGDTestFile(make_header(version=3, individuals=I, variants=V), ver3=True) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
-            igd_file = IGDFile(filename)
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
 
-            self.assertEqual(igd_file.description, TEST_DESCRIPTION)
-            self.assertEqual(igd_file.source, TEST_SOURCE)
-            self.assertEqual(igd_file.num_individuals, I)
-            self.assertEqual(igd_file.num_variants, V)
-            self.assertEqual(igd_file.ploidy, 2)
+                self.assertEqual(igd_file.description, TEST_DESCRIPTION)
+                self.assertEqual(igd_file.source, TEST_SOURCE)
+                self.assertEqual(igd_file.num_individuals, I)
+                self.assertEqual(igd_file.num_variants, V)
+                self.assertEqual(igd_file.ploidy, 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,0 +1,199 @@
+from pyigd import IGDReader, IGDWriter, IGDTransformer
+import unittest
+import tempfile
+import os
+
+TEST_SOURCE = "SOURCE"
+TEST_DESCRIPTION = "DESCRIPTION"
+
+class CanonicalTestIGD:
+    def __init__(self):
+        self.variants = [
+            (1, "A", "G", list(range(500, 1500))),
+            (1, "C", "G", list(range(0, 2000))),
+            (1, "T", "REALLYLONG", [1,2]),
+            (1, "A", "T", []),
+            (1, "G", "G", [0, 9, 19, 30, 42, 55]),
+        ]
+    
+    def write(self, filename: str):
+        with open(filename, "wb") as f:
+            w = IGDWriter(f, 2000, ploidy=1, phased=False, source="TEST", description="TESTD")
+            w.write_header()
+            for pos, ref, alt, samples in self.variants:
+                w.write_variant(pos, ref, alt, samples)
+            w.write_index()
+            w.write_variant_info()
+            w.write_individual_ids([f"ID{i}" for i in range(2000)])
+            w.write_variant_ids([f"VAR{i}" for i in range(len(self.variants))])
+            f.seek(0)
+            w.write_header()
+            
+    def readAndVerify(self, filename: str, test_case: unittest.TestCase):
+        with open(filename, "rb") as f:
+            reader = IGDReader(f)
+            test_case.assertEqual(reader.num_individuals, 2000)
+            test_case.assertEqual(reader.num_variants, len(self.variants))
+            for i, (pos, ref, alt, samples) in enumerate(self.variants):
+                test_case.assertEqual(reader.get_alt_allele(i), alt)
+                test_case.assertEqual(reader.get_ref_allele(i), ref)
+                rpos, is_missing, rsamples = reader.get_samples(i)
+                test_case.assertEqual(rpos, pos)
+                test_case.assertFalse(is_missing)
+                test_case.assertEqual(rsamples, samples)
+            test_case.assertEqual(reader.description, "TESTD")
+            test_case.assertEqual(reader.source, "TEST")
+
+
+class WriterTests(unittest.TestCase):
+    def test_write_read_simple(self):
+        """
+        Write a simple IGD file verify reading.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fn = os.path.join(tmpdir, "tmp.igd")
+            with open(fn, "wb") as f:
+                w = IGDWriter(f, 100)
+                w.write_header()
+                w.write_variant(100, "A", "G", [1, 22, 99, 101])
+                w.write_variant(101, "A", "C", list(range(200)))
+                w.write_index()
+                w.write_variant_info()
+                w.write_individual_ids([])
+                w.write_variant_ids([])
+                f.seek(0)
+                w.write_header()
+            
+            with open(fn, "rb") as f:
+                reader = IGDReader(f)
+                self.assertEqual(reader.num_individuals, 100)
+                self.assertEqual(reader.num_variants, 2)
+                self.assertEqual(reader.get_alt_allele(0), "G")
+                self.assertEqual(reader.get_alt_allele(1), "C")
+                self.assertEqual(reader.get_samples(0), (100, False, [1, 22, 99, 101]))
+                self.assertEqual(reader.get_samples(1), (101, False, list(range(200))))
+
+    def test_write_read_loop(self):
+        """
+        Write an IGD file with as many interesting features as possible and verify that reading
+        recovers all of that data.
+        """
+        test_data = CanonicalTestIGD()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fn = os.path.join(tmpdir, "test.igd")
+            test_data.write(fn)
+            test_data.readAndVerify(fn, self)
+
+    def test_out_of_order(self):
+        """
+        Writing should fail if variants are not in ascending positional order.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fn = os.path.join(tmpdir, "tmp.igd")
+            with open(fn, "wb") as f:
+                w = IGDWriter(f, 200)
+                w.write_variant(100, "A", "G", [1])
+                with self.assertRaises(AssertionError) as context:
+                    w.write_variant(99, "A", "G", [1])
+
+    def test_bad_samples(self):
+        """
+        Writing should fail if a bad sample ID is given.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fn = os.path.join(tmpdir, "tmp.igd")
+            with open(fn, "wb") as f:
+                w = IGDWriter(f, 200)
+                with self.assertRaises(AssertionError) as context:
+                    w.write_variant(100, "A", "G", [99, 98])
+
+class TransformerTests(unittest.TestCase):
+    def test_copy(self):
+        """
+        Copy an IGD exactly using IGDTransformer.
+        """
+        class MyXformer(IGDTransformer):
+            def modify_samples(self, position, is_missing, samples):
+                return samples
+
+        test_data = CanonicalTestIGD()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            in_file = os.path.join(tmpdir, "created.igd")
+            out_file = os.path.join(tmpdir, "copied.igd")
+            out_file_bv = os.path.join(tmpdir, "copied_bv.igd")
+
+            test_data.write(in_file)
+            with open(in_file, "rb") as fin, open(out_file, "wb") as fout:
+                xformer = MyXformer(fin, fout)
+                xformer.transform()
+            test_data.readAndVerify(out_file, self)
+
+            with open(in_file, "rb") as fin, open(out_file_bv, "wb") as fout:
+                xformer = MyXformer(fin, fout, use_bitvectors=True)
+                xformer.transform()
+            test_data.readAndVerify(out_file_bv, self)
+
+    def test_simple_mod(self):
+        """
+        Copy an IGD dropping the first sample of every list, using IGDTransformer.
+        """
+        class MyXformer(IGDTransformer):
+            def modify_samples(self, position, is_missing, samples):
+                return samples[1:]
+
+        test_data = CanonicalTestIGD()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            in_file = os.path.join(tmpdir, "created.igd")
+            out_file = os.path.join(tmpdir, "copied.igd")
+
+            test_data.write(in_file)
+            with open(in_file, "rb") as fin, open(out_file, "wb") as fout:
+                xformer = MyXformer(fin, fout)
+                xformer.transform()
+            # Before verifying, remove the first sample from our test data as well.
+            for i in range(len(test_data.variants)):
+                test_sample_list = test_data.variants[i][3]
+                if test_sample_list:
+                    del test_sample_list[0]
+            # The modified file should match our test data now
+            test_data.readAndVerify(out_file, self)
+            # The original file should _not_ match out test data now
+            with self.assertRaises(AssertionError) as context:
+                test_data.readAndVerify(in_file, self)
+
+    def test_simple_mod_bv(self):
+        """
+        Copy an IGD dropping the first sample of every list, using IGDTransformer.
+        """
+        class MyXformer(IGDTransformer):
+            def modify_samples(self, position, is_missing, samples):
+                for i in range(len(samples)):
+                    if samples[i]:
+                        samples[i] = 0
+                        break
+                return samples
+
+        test_data = CanonicalTestIGD()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            in_file = os.path.join(tmpdir, "created.igd")
+            out_file = os.path.join(tmpdir, "copied.igd")
+
+            test_data.write(in_file)
+            with open(in_file, "rb") as fin, open(out_file, "wb") as fout:
+                xformer = MyXformer(fin, fout, use_bitvectors=True)
+                xformer.transform()
+            # Before verifying, remove the first sample from our test data as well.
+            for i in range(len(test_data.variants)):
+                test_sample_list = test_data.variants[i][3]
+                if test_sample_list:
+                    del test_sample_list[0]
+            # The modified file should match our test data now
+            test_data.readAndVerify(out_file, self)
+            # The original file should _not_ match out test data now
+            with self.assertRaises(AssertionError) as context:
+                test_data.readAndVerify(in_file, self)
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  * IGDFile is now IGDReader, and takes an IO buffer instead of a filename. This is more flexible, and removes the need to have a context manager.
  * IGDWriter is new: create IGD files in Python.
  * IGDTransformer lets you take an input IGD buffer and modify the sample information, producing a new output IGD buffer.
  * Add sphinx docs in preparation of publishing to rtd