### PR TITLE
Use black to format code; prep docs for RTD

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest BitVector
+        python -m pip install flake8 pytest BitVector black mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -35,6 +35,12 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --statistics
+    - name: Check formatting
+      run: |
+        black pyigd/ setup.py test/ examples/ --check 
+    - name: Check typing
+      run: |
+        mypy pyigd --no-namespace-packages --ignore-missing-imports
     - name: Test with pytest
       run: |
         PYTHONPATH=$PWD pytest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.swp
 build/
 dist/
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "doc/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,23 +6,23 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'pyigd'
-copyright = '2024, Drew DeHaas'
-author = 'Drew DeHaas'
-release = '0.2'
+project = "pyigd"
+copyright = "2024, Drew DeHaas"
+author = "Drew DeHaas"
+release = "0.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = ["sphinx.ext.autodoc"]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ pyigd Documentation
    :maxdepth: 2
    :caption: Contents:
 
+   pyigd
+
 pyigd is a Python library for reading and writing Indexable Genotype Data
 (IGD) files. `IGD is a binary format <https://github.com/aprilweilab/picovcf/blob/main/IGD.FORMAT.md>`_ that is very simple and uses no
 compression, but tends to be quite small and fast.

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-pyigd
-=====
-
-.. toctree::
-   :maxdepth: 4
-
-   pyigd

--- a/docs/pyigd.rst
+++ b/docs/pyigd.rst
@@ -1,8 +1,5 @@
-pyigd package
-=============
-
-Module contents
----------------
+pyigd API
+=========
 
 .. automodule:: pyigd
    :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+BitVector

--- a/examples/igdread.py
+++ b/examples/igdread.py
@@ -15,11 +15,13 @@ with open(sys.argv[1], "rb") as f:
     print(f"Description: {igd_file.description}")
     for variant_index in range(igd_file.num_variants):
         # Approach 1: Get the samples as a list
-        print(f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}")
+        print(
+            f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}"
+        )
         position, is_missing, sample_list = igd_file.get_samples(variant_index)
-        print( (position, is_missing, len(sample_list))  )
+        print((position, is_missing, len(sample_list)))
 
         # Approach 2: Get the samples as a BitVector object
         # See https://engineering.purdue.edu/kak/dist/BitVector-3.5.0.html
         position, is_missing, bitvect = igd_file.get_samples_bv(variant_index)
-        print( (position, is_missing, bitvect.count_bits())  )
+        print((position, is_missing, bitvect.count_bits()))

--- a/examples/xform.py
+++ b/examples/xform.py
@@ -5,6 +5,7 @@ if len(sys.argv) < 3:
     print("Pass in IGD input/output filenames")
     exit(1)
 
+
 # Our own IGDTransformer. This just deletes the first sample from every variant, but
 # in general you can change the sample list any way you want. Return None to delete
 # the variant entirely.
@@ -12,7 +13,10 @@ class MyXformer(pyigd.IGDTransformer):
     def modify_samples(self, position, is_missing, samples):
         return samples[1:]
 
+
 with open(sys.argv[1], "rb") as fin, open(sys.argv[2], "wb") as fout:
     xformer = MyXformer(fin, fout, use_bitvectors=False)
     xformer.transform()
-print(f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant.")
+print(
+    f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant."
+)

--- a/examples/xform_bv.py
+++ b/examples/xform_bv.py
@@ -5,6 +5,7 @@ if len(sys.argv) < 3:
     print("Pass in IGD input/output filenames")
     exit(1)
 
+
 # Our own IGDTransformer. This just deletes the first sample from every variant, but
 # in general you can change the sample list any way you want. Return None to delete
 # the variant entirely.
@@ -16,7 +17,10 @@ class MyXformer(pyigd.IGDTransformer):
                 samples[i] = 0
         return samples
 
+
 with open(sys.argv[1], "rb") as fin, open(sys.argv[2], "wb") as fout:
     xformer = MyXformer(fin, fout, use_bitvectors=True)
     xformer.transform()
-print(f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant.")
+print(
+    f"Copied {sys.argv[1]} to {sys.argv[2]} and deleted the first sample from every variant."
+)

--- a/prep_for_commit.sh
+++ b/prep_for_commit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ev
+
+flake8 pyigd --count --select=E9,F63,F7,F82,F401 --show-source --statistics
+
+black pyigd/ setup.py test/ examples/ --check 
+
+mypy pyigd --no-namespace-packages --ignore-missing-imports
+
+pytest test/
+

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,15 @@ from setuptools import setup, find_packages
 PACKAGE_NAME = "pyigd"
 VERSION = "0.2"
 
-setup(name=PACKAGE_NAME,
-      packages=find_packages(),
-      version=VERSION,
-      description="Parser for IGD files",
-      author="Drew DeHaas",
-      author_email="",
-      url="https://aprilweilab.github.io/",
-      classifiers=[
-          "Programming Language :: Python :: 3",
-      ])
+setup(
+    name=PACKAGE_NAME,
+    packages=find_packages(),
+    version=VERSION,
+    description="Parser for IGD files",
+    author="Drew DeHaas",
+    author_email="",
+    url="https://aprilweilab.github.io/",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
+)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,5 +1,5 @@
 from pyigd import IGDReader, IGDConstants, BpPosFlags
-from pyigd import IGDFile # TODO: remove
+from pyigd import IGDFile  # TODO: remove
 import unittest
 import struct
 import tempfile
@@ -9,23 +9,46 @@ import random
 TEST_SOURCE = "SOURCE"
 TEST_DESCRIPTION = "DESCRIPTION"
 
-def make_header(magic=IGDConstants.HEADER_MAGIC,
-                version=IGDConstants.SUPPORTED_FILE_VERSION,
-                ploidy=2,
-                variants=0,
-                individuals=0,
-                fp_idx=0,
-                fp_vars=0,
-                fp_indv=0):
-    return struct.pack(IGDConstants.HEADER_FORMAT,
-        magic, version, ploidy, 0, variants, individuals, 0, fp_idx, fp_vars, fp_indv,
-        0, 0, 0, 0, 0, 0, 0)
+
+def make_header(
+    magic=IGDConstants.HEADER_MAGIC,
+    version=IGDConstants.SUPPORTED_FILE_VERSION,
+    ploidy=2,
+    variants=0,
+    individuals=0,
+    fp_idx=0,
+    fp_vars=0,
+    fp_indv=0,
+):
+    return struct.pack(
+        IGDConstants.HEADER_FORMAT,
+        magic,
+        version,
+        ploidy,
+        0,
+        variants,
+        individuals,
+        0,
+        fp_idx,
+        fp_vars,
+        fp_indv,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+
 
 def _write_u64(file_obj, value):
     file_obj.write(struct.pack("Q", value))
 
+
 def _write_u32(file_obj, value):
     file_obj.write(struct.pack("I", value))
+
 
 def _write_str(ver3, file_obj, string):
     if ver3:
@@ -33,6 +56,7 @@ def _write_str(ver3, file_obj, string):
     else:
         _write_u32(file_obj, len(string))
     file_obj.write(string.encode("utf-8"))
+
 
 class IGDTestFile(tempfile.TemporaryDirectory):
     FILENAME = "test.igd"
@@ -84,7 +108,7 @@ class IGDTestFile(tempfile.TemporaryDirectory):
                 fp_indivs = 0
 
             # If provided write the variant ids
-            var_ids = [ident for _,_,_,ident in self.variants if ident is not None]
+            var_ids = [ident for _, _, _, ident in self.variants if ident is not None]
             if var_ids:
                 fp_varids = f.tell()
                 _write_u64(f, len(var_ids))
@@ -97,7 +121,7 @@ class IGDTestFile(tempfile.TemporaryDirectory):
 
             # Gross. If this wasn't test code I wouldn't do this...
             # We're just updating the last few fields of the header to set the file locations.
-            f.seek(0 + (6*8))
+            f.seek(0 + (6 * 8))
             _write_u64(f, fp_idx)
             _write_u64(f, fp_vars)
             _write_u64(f, fp_indivs)
@@ -105,6 +129,7 @@ class IGDTestFile(tempfile.TemporaryDirectory):
             f.flush()
 
         return tmpdir
+
 
 class ReaderTests(unittest.TestCase):
     def test_good_header_no_data(self):
@@ -128,20 +153,26 @@ class ReaderTests(unittest.TestCase):
                 self.assertEqual(igd_file.num_variants, 0)
                 self.assertEqual(igd_file.ploidy, 2)
 
-
     def test_good_header_some_data(self):
         I = 10
         V = 50
 
         def rand_samples():
-            num_samples = I*2
-            count = random.randint(0, num_samples-1)
+            num_samples = I * 2
+            count = random.randint(0, num_samples - 1)
             result = list(range(num_samples))
             random.shuffle(result)
             return sorted(result[:count])
 
-        variants = list(sorted([(random.randint(0, 100_000), False, rand_samples(), None)
-                                for i in range(V)], key=lambda v: v[0]))
+        variants = list(
+            sorted(
+                [
+                    (random.randint(0, 100_000), False, rand_samples(), None)
+                    for i in range(V)
+                ],
+                key=lambda v: v[0],
+            )
+        )
 
         with IGDTestFile(make_header(individuals=I, variants=V), variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
@@ -164,16 +195,22 @@ class ReaderTests(unittest.TestCase):
 
     def test_good_indiv_ids(self):
         I = 10
-        with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I)))) as tmpdir:
+        with IGDTestFile(
+            make_header(individuals=I), indiv_ids=list(map(str, range(I)))
+        ) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
                 igd_file = IGDReader(f)
                 self.assertEqual(igd_file.num_individuals, I)
-                self.assertEqual(igd_file.get_individual_ids(), list(map(str, range(I))))
+                self.assertEqual(
+                    igd_file.get_individual_ids(), list(map(str, range(I)))
+                )
 
     def test_bad_indiv_ids(self):
         I = 10
-        with IGDTestFile(make_header(individuals=I), indiv_ids=list(map(str, range(I+1)))) as tmpdir:
+        with IGDTestFile(
+            make_header(individuals=I), indiv_ids=list(map(str, range(I + 1)))
+        ) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
                 igd_file = IGDReader(f)
@@ -182,7 +219,7 @@ class ReaderTests(unittest.TestCase):
 
     def test_bad_var_ids(self):
         V = 25
-        variants = [(i,False,[],(None if i > 5 else str(i))) for i in range(V)]
+        variants = [(i, False, [], (None if i > 5 else str(i))) for i in range(V)]
         with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
@@ -192,13 +229,12 @@ class ReaderTests(unittest.TestCase):
 
     def test_good_var_ids(self):
         V = 21
-        variants = [(i,False,[],str(i)) for i in range(V)]
+        variants = [(i, False, [], str(i)) for i in range(V)]
         with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
                 igd_file = IGDReader(f)
-                self.assertEqual(igd_file.get_variant_ids(),
-                                [v[3] for v in variants])
+                self.assertEqual(igd_file.get_variant_ids(), [v[3] for v in variants])
 
 
 class CompatTests(unittest.TestCase):
@@ -210,7 +246,7 @@ class CompatTests(unittest.TestCase):
                     _ = IGDReader(f)
 
     def test_bad_header_magic(self):
-        with IGDTestFile(make_header(magic=0xbaadf00d)) as tmpdir:
+        with IGDTestFile(make_header(magic=0xBAADF00D)) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
                 with self.assertRaises(AssertionError):
@@ -219,7 +255,9 @@ class CompatTests(unittest.TestCase):
     def test_v3_compatible(self):
         I = 10
         V = 50
-        with IGDTestFile(make_header(version=3, individuals=I, variants=V), ver3=True) as tmpdir:
+        with IGDTestFile(
+            make_header(version=3, individuals=I, variants=V), ver3=True
+        ) as tmpdir:
             filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
             with open(filename, "rb") as f:
                 igd_file = IGDReader(f)
@@ -229,6 +267,7 @@ class CompatTests(unittest.TestCase):
                 self.assertEqual(igd_file.num_individuals, I)
                 self.assertEqual(igd_file.num_variants, V)
                 self.assertEqual(igd_file.ploidy, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -6,19 +6,22 @@ import os
 TEST_SOURCE = "SOURCE"
 TEST_DESCRIPTION = "DESCRIPTION"
 
+
 class CanonicalTestIGD:
     def __init__(self):
         self.variants = [
             (1, "A", "G", list(range(500, 1500))),
             (2, "C", "G", list(range(0, 2000))),
-            (3, "T", "REALLYLONG", [1,2]),
+            (3, "T", "REALLYLONG", [1, 2]),
             (4, "A", "T", []),
             (5, "G", "G", [0, 9, 19, 30, 42, 55]),
         ]
-    
+
     def write(self, filename: str):
         with open(filename, "wb") as f:
-            w = IGDWriter(f, 2000, ploidy=1, phased=False, source="TEST", description="TESTD")
+            w = IGDWriter(
+                f, 2000, ploidy=1, phased=False, source="TEST", description="TESTD"
+            )
             w.write_header()
             for pos, ref, alt, samples in self.variants:
                 w.write_variant(pos, ref, alt, samples)
@@ -28,7 +31,7 @@ class CanonicalTestIGD:
             w.write_variant_ids([f"VAR{i}" for i in range(len(self.variants))])
             f.seek(0)
             w.write_header()
-            
+
     def readAndVerify(self, filename: str, test_case: unittest.TestCase):
         with open(filename, "rb") as f:
             reader = IGDReader(f)
@@ -63,7 +66,7 @@ class WriterTests(unittest.TestCase):
                 w.write_variant_ids([])
                 f.seek(0)
                 w.write_header()
-            
+
             with open(fn, "rb") as f:
                 reader = IGDReader(f)
                 self.assertEqual(reader.num_individuals, 100)
@@ -107,11 +110,13 @@ class WriterTests(unittest.TestCase):
                 with self.assertRaises(AssertionError) as context:
                     w.write_variant(100, "A", "G", [99, 98])
 
+
 class TransformerTests(unittest.TestCase):
     def test_copy(self):
         """
         Copy an IGD exactly using IGDTransformer.
         """
+
         class MyXformer(IGDTransformer):
             def modify_samples(self, position, is_missing, samples):
                 return samples
@@ -137,6 +142,7 @@ class TransformerTests(unittest.TestCase):
         """
         Copy an IGD dropping the first sample of every list, using IGDTransformer.
         """
+
         class MyXformer(IGDTransformer):
             def modify_samples(self, position, is_missing, samples):
                 return samples[1:]
@@ -165,6 +171,7 @@ class TransformerTests(unittest.TestCase):
         """
         Copy an IGD dropping the first sample of every list, using IGDTransformer.
         """
+
         class MyXformer(IGDTransformer):
             def modify_samples(self, position, is_missing, samples):
                 for i in range(len(samples)):
@@ -197,6 +204,7 @@ class TransformerTests(unittest.TestCase):
         """
         Copy an IGD dropping the first variant, using IGDTransformer
         """
+
         class MyXformer(IGDTransformer):
             def modify_samples(self, position, is_missing, samples):
                 if position == 1:
@@ -234,6 +242,7 @@ class TransformerTests(unittest.TestCase):
                     self.assertEqual(rsamples, samples)
                 self.assertEqual(reader.description, "TESTD")
                 self.assertEqual(reader.source, "TEST")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* `./prep_for_commit.sh` runs all pre-commit checks now
* CI checks code formatting
* Docs are built more nicely for read-the-docs integration