### PR TITLE
Remove BitVector, and just use a list of 1,0 instead

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest BitVector black mypy
+        python -m pip install flake8 pytest black mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/examples/igdread.py
+++ b/examples/igdread.py
@@ -14,14 +14,13 @@ with open(sys.argv[1], "rb") as f:
     print(f"Source: {igd_file.source}")
     print(f"Description: {igd_file.description}")
     for variant_index in range(igd_file.num_variants):
-        # Approach 1: Get the samples as a list
+        # Approach 1: Get the samples as a list of sample indexes
         print(
             f"REF: {igd_file.get_ref_allele(variant_index)}, ALT: {igd_file.get_alt_allele(variant_index)}"
         )
         position, is_missing, sample_list = igd_file.get_samples(variant_index)
         print((position, is_missing, len(sample_list)))
 
-        # Approach 2: Get the samples as a BitVector object
-        # See https://engineering.purdue.edu/kak/dist/BitVector-3.5.0.html
+        # Approach 2: Get the samples as a list of length num_samples, where each position is either 1 or 0
         position, is_missing, bitvect = igd_file.get_samples_bv(variant_index)
-        print((position, is_missing, bitvect.count_bits()))
+        print((position, is_missing, sum(bitvect)))

--- a/examples/xform_bv.py
+++ b/examples/xform_bv.py
@@ -11,7 +11,7 @@ if len(sys.argv) < 3:
 # the variant entirely.
 class MyXformer(pyigd.IGDTransformer):
     def modify_samples(self, position, is_missing, samples):
-        # BitVector version. The ith element being 1 means the ith sample has the variant.
+        # 1,0 vector version. The ith element being 1 means the ith sample has the variant.
         for i in range(len(samples)):
             if samples[i]:
                 samples[i] = 0


### PR DESCRIPTION
The only reason to use BitVector was convenience and space (it uses <= 1/32 the space of a list). However, users can always convert to BitVector if they need space saving (for cases where they save more than just the current variant). BitVector was more than 6x slower than just using a Python list.