### PR TITLE
Add IGDReader.lower_bound_position

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -67,6 +67,25 @@ found by scanning the IGD index:
         # Do something with sample_list
 
 
+Or even more efficient is to use :py:meth:`pyigd.IGDReader.lower_bound_position` to binary search for
+first position greater-than-or-equal-to the start of the range, and then traverse until the end.
+
+::
+
+  import pyigd
+
+  my_range = (5_000_000, 10_000_000)  # 5MBP to 10MBP
+  with open("myfile.igd", "rb") as f:
+    igd_file = pyigd.IGDReader(f)
+    variant_index = igd_file.lower_bound_position(my_range[0])
+    while variant_index < igd_file.num_variants:
+      position, flags = igd_file.get_position_and_flags(variant_index)
+      if position >= my_range[1]:
+        break
+      _, _, sample_list = igd_file.get_samples(variant_index)
+      # Do something with sample_list
+
+
 Runs of homozygosity
 --------------------
 

--- a/pyigd/__init__.py
+++ b/pyigd/__init__.py
@@ -395,6 +395,30 @@ class IGDReader:
                 result.append(_read_string(self._version, self.file_obj))
         return result
 
+    def lower_bound_position(self, position) -> int:
+        """
+        Return the first variant index with position that is greater than or equal to the given position.
+        Will return `num_variants` if the given position is greater than all positions in the IGD.
+
+        :param position: The position to search for.
+        :type position: int
+        :return: The first variant index with position greater than or equal to the given position.
+        :rtype: int
+        """
+        low = 0
+        high = self.num_variants - 1
+        mid = high
+        while low <= high:
+            mid = low + ((high - low) // 2)
+            mid_pos, _ = self.get_position_and_flags(mid)
+            if mid_pos < position:
+                low = mid + 1
+            elif mid_pos > position:
+                high = mid - 1
+            else:
+                return mid
+        return low
+
 
 class IGDFile(IGDReader, AbstractContextManager):
     """

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -238,6 +238,27 @@ class ReaderTests(unittest.TestCase):
                 igd_file = IGDReader(f)
                 self.assertEqual(igd_file.get_variant_ids(), [v[3] for v in variants])
 
+    def test_lower_bound(self):
+        V = 21
+        variants = [(i * 10, False, [], str(i)) for i in range(V)]
+        with IGDTestFile(make_header(variants=V), variants=variants) as tmpdir:
+            filename = os.path.join(tmpdir, IGDTestFile.FILENAME)
+            with open(filename, "rb") as f:
+                igd_file = IGDReader(f)
+
+                self.assertEqual(0, igd_file.lower_bound_position(0))
+                self.assertEqual(
+                    igd_file.num_variants, igd_file.lower_bound_position(100_000)
+                )
+                self.assertEqual(1, igd_file.lower_bound_position(10))
+                self.assertEqual(9, igd_file.lower_bound_position(90))
+                self.assertEqual(10, igd_file.lower_bound_position(91))
+                self.assertEqual(10, igd_file.lower_bound_position(92))
+                self.assertEqual(10, igd_file.lower_bound_position(93))
+                self.assertEqual(10, igd_file.lower_bound_position(99))
+                self.assertEqual(10, igd_file.lower_bound_position(100))
+                self.assertEqual(11, igd_file.lower_bound_position(101))
+
 
 class CompatTests(unittest.TestCase):
     def test_bad_header_ver(self):


### PR DESCRIPTION
Binary search for a position: hundreds or thousands of times faster on a large file, when seeking to a particular range.